### PR TITLE
Add missing update override to MultipleCustomUIHud

### DIFF
--- a/src/main/java/com/buuz135/mhud/MultipleCustomUIHud.java
+++ b/src/main/java/com/buuz135/mhud/MultipleCustomUIHud.java
@@ -6,6 +6,7 @@ import com.hypixel.hytale.server.core.ui.builder.UICommandBuilder;
 import com.hypixel.hytale.server.core.universe.PlayerRef;
 import org.checkerframework.checker.nullness.compatqual.NonNullDecl;
 
+import javax.annotation.Nonnull;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.util.HashMap;
@@ -44,6 +45,14 @@ class MultipleCustomUIHud extends CustomUIHud {
             } catch (IllegalAccessException | InvocationTargetException e) {
                 throw new RuntimeException(e);
             }
+        }
+    }
+
+    @Override
+    public void update(boolean clear, @Nonnull UICommandBuilder commandBuilder) {
+        for (String key : customHuds.keySet()) {
+            var hud = customHuds.get(key);
+            hud.update(clear, commandBuilder);
         }
     }
 


### PR DESCRIPTION
The update method was not being called on the individual CustomUIHuds because it wasn't overridden in MultipleCustomUIHud.
Added: 
 `@Override public void update(boolean clear, @Nonnull UICommandBuilder commandBuilder)` 
to delegate the call to all registered HUDs.
This ensures all custom HUDs properly receive update events. 

Tested locally: https://github.com/Shiirroo/TPS/blob/master/src/main/java/de/shiirroo/tps/hud/TpsHud.java